### PR TITLE
remove unban timer when ban is added

### DIFF
--- a/lua/ulx/xgui/server/sv_bans.lua
+++ b/lua/ulx/xgui/server/sv_bans.lua
@@ -259,6 +259,11 @@ function bans.init()
 	ULib.addBan = function( steamid, time, reason, name, admin )
 		banfunc( steamid, time, reason, name, admin )
 		bans.processBans()
+		
+		if timer.Exists( "xgui_unban" .. steamid ) then
+			timer.Remove( "xgui_unban" .. steamid )
+		end
+
 		bans.unbanTimer()
 	end
 

--- a/lua/ulx/xgui/server/sv_bans.lua
+++ b/lua/ulx/xgui/server/sv_bans.lua
@@ -255,18 +255,16 @@ function bans.init()
 	xgui.addCmd( "getbans", bans.sendBansToUser )
 
 	--Hijack the addBan function to update XGUI's ban info.
-	local banfunc = ULib.addBan
-	ULib.addBan = function( steamid, time, reason, name, admin )
-		banfunc( steamid, time, reason, name, admin )
+	hook.Add(ULib.HOOK_USER_BANNED, "ULXHandleBanChange", function(steamID, t)
 		bans.processBans()
 		
 		if timer.Exists( "xgui_unban" .. steamid ) then
 			timer.Remove( "xgui_unban" .. steamid )
 		end
-
+		
 		bans.unbanTimer()
-	end
-
+	end)
+	
 	--Hijack the unBan function to update XGUI's ban info.
 	local unbanfunc = ULib.unban
 	ULib.unban = function( steamid, admin )

--- a/lua/ulx/xgui/server/sv_bans.lua
+++ b/lua/ulx/xgui/server/sv_bans.lua
@@ -255,16 +255,16 @@ function bans.init()
 	xgui.addCmd( "getbans", bans.sendBansToUser )
 
 	--Hijack the addBan function to update XGUI's ban info.
-	hook.Add(ULib.HOOK_USER_BANNED, "ULXHandleBanChange", function(steamID, t)
+	hook.Add(ULib.HOOK_USER_BANNED, "ULXHandleBanChange", function(steamid, t)
 		bans.processBans()
 		
 		if timer.Exists( "xgui_unban" .. steamid ) then
 			timer.Remove( "xgui_unban" .. steamid )
 		end
-		
+
 		bans.unbanTimer()
 	end)
-	
+
 	--Hijack the unBan function to update XGUI's ban info.
 	local unbanfunc = ULib.unban
 	ULib.unban = function( steamid, admin )

--- a/lua/ulx/xgui/server/sv_bans.lua
+++ b/lua/ulx/xgui/server/sv_bans.lua
@@ -254,7 +254,6 @@ function bans.init()
 	end
 	xgui.addCmd( "getbans", bans.sendBansToUser )
 
-	--Hijack the addBan function to update XGUI's ban info.
 	hook.Add(ULib.HOOK_USER_BANNED, "ULXHandleBanChange", function(steamid, t)
 		bans.processBans()
 		


### PR DESCRIPTION
If a user is going to be unbanned in <1 hour and you adjust their ban to a time >1 hour they will still be unbanned after the shorter duration